### PR TITLE
Report Elasticsearch Bulk API errors and exit on error.

### DIFF
--- a/src/main/java/gov/nasa/pds/registry/mgr/RegistryManagerCli.java
+++ b/src/main/java/gov/nasa/pds/registry/mgr/RegistryManagerCli.java
@@ -82,7 +82,8 @@ public class RegistryManagerCli
 
         System.out.println();
         System.out.println("Options:");
-        System.out.println("  -help  Print help for a command");
+        System.out.println("  -help        Print help for a command");
+        System.out.println("  -v <value>   Log verbosity: DEBUG, INFO, WARN, ERROR. Default is INFO.");
         
         System.out.println();
         System.out.println("Pass -help after any command to see command-specific usage information, for example,");
@@ -111,6 +112,8 @@ public class RegistryManagerCli
             System.exit(1);
         }
 
+        initLogger();
+        
         // Run command
         if(!runCommand())
         {
@@ -118,6 +121,37 @@ public class RegistryManagerCli
         }        
     }
 
+    
+    private void initLogger()
+    {
+        String verbosity = cmdLine.getOptionValue("v", "INFO");
+        int level = parseLogLevel(verbosity);
+        Logger.setLevel(level);
+    }
+    
+
+    private static int parseLogLevel(String verbosity)
+    {
+        // Logger is not setup yet. Print to console.
+        if(verbosity == null)
+        {
+            System.out.println("[WARN] Log verbosity is not set. Will use 'INFO'.");
+            return Logger.LEVEL_INFO;
+        }
+        
+        switch(verbosity.toUpperCase())
+        {
+        case "DEBUG": return Logger.LEVEL_DEBUG;
+        case "INFO": return Logger.LEVEL_INFO;
+        case "WARN": return Logger.LEVEL_WARN;
+        case "ERROR": return Logger.LEVEL_ERROR;
+        }
+
+        // Logger is not setup yet. Print to console.
+        System.out.println("[WARN] Invalid log verbosity '" + verbosity + "'. Will use 'INFO'.");
+        return Logger.LEVEL_INFO;
+    }
+    
     
     private boolean runCommand()
     {


### PR DESCRIPTION
**Test Instructions**
- Harvest any product (run harvest tool)
- Edit generated JSON to make a value of a date field such as `start_date_time` invalid. You can replace a date value with string `test`.
- Run registry manager to load edited JSON.
- Registry manager should report an error and exit.

Fixes https://github.com/NASA-PDS/pds-registry-mgr-elastic/issues/25

