### PR TITLE
Print version command

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -67,6 +67,18 @@
 
     <build>
         <plugins>
+            <!-- Add POM version to JAR's manifest -->
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-jar-plugin</artifactId>
+                <configuration>
+                    <archive>
+                        <manifest>
+                            <addDefaultImplementationEntries>true</addDefaultImplementationEntries>
+                        </manifest>
+                    </archive>
+                </configuration>
+            </plugin>
             <!-- SpringBoot single JAR executable. -->
             <plugin>
                 <groupId>org.springframework.boot</groupId>

--- a/src/main/java/gov/nasa/pds/registry/mgr/RegistryManagerCli.java
+++ b/src/main/java/gov/nasa/pds/registry/mgr/RegistryManagerCli.java
@@ -53,7 +53,7 @@ public class RegistryManagerCli
     /**
      * Print main help screen.
      */
-    public void printHelp()
+    public static void printHelp()
     {
         System.out.println("Usage: registry-manager <command> <options>");
 
@@ -81,6 +81,10 @@ public class RegistryManagerCli
         System.out.println("  update-schema        Update registry schema");
 
         System.out.println();
+        System.out.println("Other:");
+        System.out.println("  -V, --version        Print Registry Manager version");
+
+        System.out.println();
         System.out.println("Options:");
         System.out.println("  -help        Print help for a command");
         System.out.println("  -v <value>   Log verbosity: DEBUG, INFO, WARN, ERROR. Default is INFO.");
@@ -88,6 +92,16 @@ public class RegistryManagerCli
         System.out.println();
         System.out.println("Pass -help after any command to see command-specific usage information, for example,");
         System.out.println("  registry-manager load-data -help");
+    }
+
+    
+    /**
+     * Print Registry Manager version
+     */
+    public static void printVersion()
+    {
+        String version = RegistryManagerCli.class.getPackage().getImplementationVersion();
+        System.out.println("Registry Manager version: " + version);
     }
 
 
@@ -101,9 +115,16 @@ public class RegistryManagerCli
         if(args.length == 0)
         {
             printHelp();
-            System.exit(1);
+            System.exit(0);
         }
 
+        // Version
+        if(args.length == 1 && ("-V".equals(args[0]) || "--version".equals(args[0])))
+        {
+            printVersion();
+            System.exit(0);
+        }        
+        
         // Parse command line arguments
         if(!parse(args))
         {


### PR DESCRIPTION
See https://github.com/NASA-PDS/pds-registry-app/issues/185

**Test Instruction**
Run Registry Manager with either `-V` or `--version` parameters to print the version. The printed version should match the version in the POM file.
```
registry-manager --version
registry-manager -V
```
Output:
```
Registry Manager version: 4.2.0-SNAPSHOT
```
