### PR TITLE
Use "-force" flag to replace missing field definitions with "keyword" (string) data type

### DIFF
--- a/src/main/java/gov/nasa/pds/registry/mgr/RegistryManagerCli.java
+++ b/src/main/java/gov/nasa/pds/registry/mgr/RegistryManagerCli.java
@@ -300,7 +300,7 @@ public class RegistryManagerCli
         bld = Option.builder("updateSchema").hasArg().argName("y/n");
         options.addOption(bld.build());
 
-        bld = Option.builder("fixMissingFD");
+        bld = Option.builder("force");
         options.addOption(bld.build());
 
         bld = Option.builder("ldd").hasArg().argName("url");

--- a/src/main/java/gov/nasa/pds/registry/mgr/cmd/data/LoadDataCmd.java
+++ b/src/main/java/gov/nasa/pds/registry/mgr/cmd/data/LoadDataCmd.java
@@ -158,7 +158,7 @@ public class LoadDataCmd implements CliCommand
         System.out.println("  -es <url>             Elasticsearch URL. Default is http://localhost:9200");
         System.out.println("  -index <name>         Elasticsearch index name. Default is 'registry'");
         System.out.println("  -updateSchema <y/n>   Update registry schema. Default is 'yes'");
-        System.out.println("  -fixMissingFD         Use 'keyword' ES datatype for missing field definitions.");
+        System.out.println("  -force                Use 'keyword' ES datatype for missing field definitions.");
 
         System.out.println();
     }

--- a/src/main/java/gov/nasa/pds/registry/mgr/cmd/data/LoadDataCmd.java
+++ b/src/main/java/gov/nasa/pds/registry/mgr/cmd/data/LoadDataCmd.java
@@ -65,7 +65,7 @@ public class LoadDataCmd implements CliCommand
         
         String tmp = cmdLine.getOptionValue("updateSchema", "Y");
         boolean updateSchema = ParamParserUtils.parseYesNo("updateSchema", tmp);
-        boolean fixMissingFDs = cmdLine.hasOption("fixMissingFD");
+        boolean fixMissingFDs = cmdLine.hasOption("force");
         
         RegistryManager.init(cfg);
 

--- a/src/main/java/gov/nasa/pds/registry/mgr/cmd/dd/UpdateSchemaCmd.java
+++ b/src/main/java/gov/nasa/pds/registry/mgr/cmd/dd/UpdateSchemaCmd.java
@@ -50,7 +50,7 @@ public class UpdateSchemaCmd implements CliCommand
         cfg.indexName = cmdLine.getOptionValue("index", Constants.DEFAULT_REGISTRY_INDEX);
         cfg.authFile = cmdLine.getOptionValue("auth");
 
-        boolean fixMissingFDs = cmdLine.hasOption("fixMissingFD");
+        boolean fixMissingFDs = cmdLine.hasOption("force");
         
         RegistryManager.init(cfg);
         
@@ -86,7 +86,7 @@ public class UpdateSchemaCmd implements CliCommand
         System.out.println("  -auth <file>     Authentication config file");
         System.out.println("  -es <url>        Elasticsearch URL. Default is http://localhost:9200");
         System.out.println("  -index <name>    Elasticsearch index name. Default is 'registry'");
-        System.out.println("  -fixMissingFD    Use 'keyword' ES datatype for missing field definitions.");        
+        System.out.println("  -force           Use 'keyword' ES datatype for missing field definitions.");        
         System.out.println();
     }
 


### PR DESCRIPTION
## 🗒️ Summary
Use "-force" flag to replace missing field definitions with "keyword" (string) data type
