### PR TITLE
Fix TestSchemaDao compilation error from stale boolean arg in getDataTypes call

### DIFF
--- a/src/test/java/tt/TestSchemaDao.java
+++ b/src/test/java/tt/TestSchemaDao.java
@@ -61,7 +61,7 @@ public class TestSchemaDao
             ids.add("pds:Property_Map/pds:identifier");
             ids.add("abc:test");
             
-            List<Tuple> results = dao.getDataTypes(ids, false);
+            List<Tuple> results = dao.getDataTypes(ids);
             if(results == null) return;
             
             System.out.println("New fields:");


### PR DESCRIPTION
## 🗒️ Summary

Removes a stale `boolean` argument from the `getDataTypes` call in `TestSchemaDao.java`. The `DataDictionaryDao.getDataTypes` method signature in `registry-common` 2.4.2 only accepts a `Collection<String>` — the second argument was no longer valid and caused a compilation failure.

> 🤖 AI code assistance: ~100% of this change was identified and applied with Claude Code assistance.

## ⚙️ Test Data and/or Report

This is a one-line compile fix. The change resolves the Maven compilation error:
```
[ERROR] method getDataTypes in class DataDictionaryDao cannot be applied to given types;
  required: java.util.Collection<java.lang.String>
  found:    java.util.Set<java.lang.String>,boolean
```

## ♻️ Related Issues

N/A

## 🤓 Reviewer Checklist

- [ ] Documentation updated (if applicable)
- [ ] No security concerns introduced
- [ ] Tests pass
- [ ] No breaking changes

🤖 Generated with [Claude Code](https://claude.ai/claude-code)