### PR TITLE
Fix export-dd crash and add namespace filter with correct pagination

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -79,7 +79,7 @@ POSSIBILITY OF SUCH DAMAGE.
         <dependency>
             <groupId>gov.nasa.pds</groupId>
             <artifactId>registry-common</artifactId>
-            <version>2.4.4</version>
+            <version>2.5.0-SNAPSHOT</version>
         </dependency>
         <!-- JSON parser -->
         <dependency>

--- a/src/main/java/gov/nasa/pds/registry/mgr/cmd/dd/ExportDDCmd.java
+++ b/src/main/java/gov/nasa/pds/registry/mgr/cmd/dd/ExportDDCmd.java
@@ -41,11 +41,12 @@ public class ExportDDCmd implements CliCommand
         
         String esUrl = CliCommand.getUsersRegistry(cmdLine);
         String authPath = cmdLine.getOptionValue("auth");
+        String namespace = cmdLine.getOptionValue("ns");
 
         System.out.println("Elasticsearch URL: " + esUrl);
         System.out.println();
-        
-        DDDataExporter exp = new DDDataExporter(esUrl, authPath);
+
+        DDDataExporter exp = new DDDataExporter(esUrl, authPath, namespace);
         exp.export(new File(filePath));
     }
 
@@ -61,10 +62,11 @@ public class ExportDDCmd implements CliCommand
         System.out.println("Export data from registry data dictionary");
         System.out.println();
         System.out.println("Required parameters:");
-        System.out.println("  -file <path>      Output file path");        
+        System.out.println("  -file <path>      Output file path");
         System.out.println("Optional parameters:");
         System.out.println("  -auth <file>      Authentication config file");
         System.out.println("  -es <url>         (deprecated) File URI to the configuration to connect to the registry. For example, file:///home/user/.pds/mcp.xml. Default is app:/connections/direct/localhost.xml");
+        System.out.println("  -ns <namespace>   Filter export to a specific LDD namespace (e.g. 'lro'). Exports all namespaces if not specified.");
         System.out.println("  -registry <url>   File URI to the configuration to connect to the registry. For example, file:///home/user/.pds/mcp.xml. Default is app:/connections/direct/localhost.xml");
         System.out.println();
     }

--- a/src/main/java/gov/nasa/pds/registry/mgr/dao/DataExporter.java
+++ b/src/main/java/gov/nasa/pds/registry/mgr/dao/DataExporter.java
@@ -1,6 +1,7 @@
 package gov.nasa.pds.registry.mgr.dao;
 
 import java.io.File;
+import java.util.List;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -74,13 +75,14 @@ public abstract class DataExporter
           Request.Search req = client.createSearchRequest().setIndex(conFact.getIndexName());
           req = createRequest(req, BATCH_SIZE, searchAfter);
           Response.Search resp = client.performRequest(req);
-          thisBatchSize = resp.batch().size();
-          numDocs += resp.batch().size();
-          searchAfter = ""; // FIXME: needs to be the last ID from the batch()
+          List<Object> batch = resp.batch();
+          thisBatchSize = batch.size();
+          numDocs += thisBatchSize;
+          searchAfter = resp.lastSortValue();
           if (numDocs % PRINT_STATUS_SIZE == 0) {
             log.info("Exported " + numDocs + " document(s)");
           }
-        } while (thisBatchSize == BATCH_SIZE);
+        } while (thisBatchSize == BATCH_SIZE && searchAfter != null);
         if (numDocs == 0) {
           log.info("No documents found");
         } else {

--- a/src/main/java/gov/nasa/pds/registry/mgr/dao/dd/DDDataExporter.java
+++ b/src/main/java/gov/nasa/pds/registry/mgr/dao/dd/DDDataExporter.java
@@ -10,18 +10,25 @@ import gov.nasa.pds.registry.mgr.dao.DataExporter;
  */
 public class DDDataExporter extends DataExporter
 {
+    private final String namespace;
+
     /**
      * Constructor
      * @param esUrl Elasticsearch URL
-     * @param indexName Elasticsearch index name
      * @param authConfigFile authentication configuration file
+     * @param namespace optional namespace filter (e.g. "lro"); null exports all
      */
-    public DDDataExporter(String esUrl, String authConfigFile)
+    public DDDataExporter(String esUrl, String authConfigFile, String namespace)
     {
         super(esUrl, "-dd", authConfigFile);
+        this.namespace = namespace;
     }
+
     @Override
     protected Search createRequest(Search req, int batchSize, String searchAfter) {
+      if (namespace != null && !namespace.isBlank()) {
+        return req.all("attr_ns", namespace, "es_field_name", batchSize, searchAfter);
+      }
       return req.all("es_field_name", batchSize, searchAfter);
     }
 


### PR DESCRIPTION
## Summary
- **Fix** `DataExporter`: use `resp.lastSortValue()` for correct `search_after` pagination instead of the broken `FIXME` empty-string placeholder — export now correctly iterates all batches
- **Add** `DDDataExporter`: accept optional namespace parameter and filter on `attr_ns` when provided, so `export-dd -ns <ns>` returns only entries for that namespace
- **Wire** `ExportDDCmd`: pass `-ns` flag through to `DDDataExporter`
- **Update** `pom.xml`: bump `registry-common` to 2.5.0-SNAPSHOT for `lastSortValue()` API (see NASA-PDS/registry-common#289)

## Test plan
- [ ] Run `registry-manager export-dd -registry ... -auth ... -file /tmp/out.json` — confirm no crash, file is populated
- [ ] Run with `-ns lro` — confirm only lro entries exported
- [ ] Run against an index with >100 documents — confirm all pages exported
- [ ] Run `export-dd` without `-ns` — confirm all namespaces still exported

## Related issues
Fixes NASA-PDS/registry-loader#83, addresses NASA-PDS/registry-loader#82

🤖 Generated with [Claude Code](https://claude.ai/claude-code)